### PR TITLE
Fixed json response for metric snapshot to include only the valid attrs

### DIFF
--- a/app/models/metric_configuration.rb
+++ b/app/models/metric_configuration.rb
@@ -15,14 +15,6 @@ class MetricConfiguration < ActiveRecord::Base
     json = super(options)
     json['metric'] = metric_snapshot.as_json(except: [:id, :created_at, :updated_at])
 
-    # Type is considered by ActiveRecord as an implementation detail and so it is ignored by as_json
-    # Here we set it, since it is important in our case
-    if metric_snapshot.is_a?(NativeMetricSnapshot)
-      json['metric']['type'] = 'NativeMetricSnapshot'
-    elsif metric_snapshot.is_a?(CompoundMetricSnapshot)
-      json['metric']['type'] = 'CompoundMetricSnapshot'
-    end
-
     return json
   end
 

--- a/app/models/metric_snapshot.rb
+++ b/app/models/metric_snapshot.rb
@@ -4,4 +4,18 @@ class MetricSnapshot < ActiveRecord::Base
   validates :name, :code, :scope, presence: true
   validates :metric_collector_name, presence: true, if: "type == 'NativeMetricSnapshot'"
   validates :script, presence: true, if: "type == 'CompoundMetricSnapshot'"
+
+  def as_json(options={})
+    json = super(options)
+    # Type is considered by ActiveRecord as an implementation detail and so it is ignored by as_json
+    # Here we set it, since it is important in our case
+    if self.is_a?(NativeMetricSnapshot)
+      json['type'] = 'NativeMetricSnapshot'
+      json.delete("script")
+    elsif self.is_a?(CompoundMetricSnapshot)
+      json['type'] = 'CompoundMetricSnapshot'
+      json.delete("metric_collector_name")
+    end
+    return json
+  end
 end

--- a/spec/models/metric_configuration_spec.rb
+++ b/spec/models/metric_configuration_spec.rb
@@ -20,33 +20,14 @@ RSpec.describe MetricConfiguration, :type => :model do
 
   describe 'methods' do
     describe 'as_json' do
-      subject { FactoryGirl.build(:metric_configuration) }
+      subject { FactoryGirl.build(:metric_configuration, metric_snapshot: FactoryGirl.build(:native_metric_snapshot)) }
 
-      context 'with a NativeMetricSnapshot' do
-        let!(:metric_snapshot) { FactoryGirl.build(:native_metric_snapshot) }
-
-        before do
-          subject.metric_snapshot = metric_snapshot
-        end
-
-        it 'is expected to set the metric attribute from hash' do
-          metric_snapshot_json = metric_snapshot.as_json(except: [:id, :created_at, :updated_at])
-          metric_snapshot_json['type'] = 'NativeMetricSnapshot'
-          expect(subject.as_json['metric']).to eq(metric_snapshot_json)
-        end
-      end
-
-      context 'with a CompoundMetricSnapshot' do
-        let!(:metric_snapshot) { FactoryGirl.build(:compound_metric_snapshot) }
-
-        before do
-          subject.metric_snapshot = metric_snapshot
-        end
-
-        it 'is expected to set the metric attribute from hash' do
-          metric_snapshot_json = metric_snapshot.as_json(except: [:id, :created_at, :updated_at])
-          metric_snapshot_json['type'] = 'CompoundMetricSnapshot'
-          expect(subject.as_json['metric']).to eq(metric_snapshot_json)
+      context 'with a generic Metric Snapshot' do
+        it 'is expected to add the metric snapshot value to the hash' do
+          subject.metric_snapshot.expects(:as_json).returns({})
+          subject_json_hash = subject.as_json
+          expect(subject_json_hash).to include("metric")
+          expect(subject_json_hash["metric"]).to eq({})
         end
       end
     end

--- a/spec/models/metric_snapshot_spec.rb
+++ b/spec/models/metric_snapshot_spec.rb
@@ -10,4 +10,40 @@ RSpec.describe MetricSnapshot, :type => :model do
     it { is_expected.to validate_presence_of(:code) }
     it { is_expected.to validate_presence_of(:scope) }
   end
+
+  describe 'as_json' do
+    context 'with a native metric snapshot' do
+      subject { FactoryGirl.build(:native_metric_snapshot) }
+
+      it 'should not include a script value' do
+        expect(subject.as_json).to_not include("script")
+      end
+
+      it 'should include metric_collector_name' do
+        expect(subject.as_json).to include("metric_collector_name")
+        expect(subject.metric_collector_name).to eq(subject.as_json['metric_collector_name'])
+      end
+
+      it 'is expected to set the type to native_metric' do
+        expect(subject.as_json['type']).to eq('NativeMetricSnapshot')
+      end
+    end
+
+    context 'with a compound metric snapshot' do
+      subject { FactoryGirl.build(:compound_metric_snapshot) }
+
+      it 'should not include a metric_collector_name' do
+        expect(subject.as_json).to_not include('metric_collector_name')
+      end
+
+      it 'should include script' do
+        expect(subject.as_json).to include('script')
+        expect(subject.script).to eq(subject.as_json['script'])
+      end
+
+      it 'is expected to set the type to compound_metric' do
+        expect(subject.as_json['type']).to eq('CompoundMetricSnapshot')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Now the metric type is added to the json hash on the as_json method on the
MetricSnapshot instead of the MetricConfiguration. Also moved the tests
that verified this attribute to the metric snapshot tests

Signed off by: Pedro Scocco <pedroscocco@gmail.com>