### PR TITLE
New scope format

### DIFF
--- a/app/controllers/metric_configurations_controller.rb
+++ b/app/controllers/metric_configurations_controller.rb
@@ -97,6 +97,6 @@ class MetricConfigurationsController < ApplicationController
   end
 
   def all_params
-    params.require(:metric_configuration).permit(:weight, :aggregation_form, :reading_group_id, :kalibro_configuration_id, metric: [:script, :description, :scope, :name, :type, :metric_collector_name, :code, :languages])
+    params.require(:metric_configuration).permit(:weight, :aggregation_form, :reading_group_id, :kalibro_configuration_id, metric: [:script, :description, { scope: :type }, :name, :type, :metric_collector_name, :code, :languages])
   end
 end

--- a/app/models/metric_snapshot.rb
+++ b/app/models/metric_snapshot.rb
@@ -21,4 +21,8 @@ class MetricSnapshot < ActiveRecord::Base
     end
     return json
   end
+
+  def scope=(value)
+    value.is_a?(Hash) ? super(value["type"]) : errors.add(:scope, "#{value} invalid")
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -62,7 +62,7 @@ END
 acc = NativeMetricSnapshot.create(
   name: "Afferent Connections per Class (used to calculate COF - Coupling Factor)",
   description: "", code: "acc", metric_collector_name: "Analizo",
-  scope: "CLASS")
+  scope: {'type' => "CLASS"})
 
 acc_metric_configuration = MetricConfiguration.create(
   metric_snapshot_id: acc.id, weight: 2.0, aggregation_form: "MEAN",
@@ -81,7 +81,7 @@ acc_metric_configuration = MetricConfiguration.create(
 
 accm = NativeMetricSnapshot.create(
   name: "Average Cyclomatic Complexity per Method", description: "",
-  code: "accm", metric_collector_name: "Analizo", scope: "CLASS")
+  code: "accm", metric_collector_name: "Analizo", scope: {'type' => "CLASS"})
 
 accm_metric_configuration = MetricConfiguration.create(
   metric_snapshot_id: accm.id, weight: 2.0, aggregation_form: "MEAN", reading_group_id: scholar.id,
@@ -100,7 +100,7 @@ accm_metric_configuration = MetricConfiguration.create(
 
 amloc = NativeMetricSnapshot.create(
   name: "Average Method Lines of Code", description: "", code: "amloc", metric_collector_name: "Analizo",
-  scope: "CLASS")
+  scope: {'type' => "CLASS"})
 
 amloc_metric_configuration = MetricConfiguration.create(
   metric_snapshot_id: amloc.id, weight: 1.0, aggregation_form: "MEAN", reading_group_id: scholar.id,
@@ -119,7 +119,7 @@ amloc_metric_configuration = MetricConfiguration.create(
 
 anpm = NativeMetricSnapshot.create(
   name: "Average Number of Parameters per Method", description: "", code: "anpm", metric_collector_name: "Analizo",
-  scope: "CLASS")
+  scope: {'type' => "CLASS"})
 
 anpm_metric_configuration = MetricConfiguration.create(
   metric_snapshot_id: anpm.id, weight: 1.0, aggregation_form: "MEAN", reading_group_id: scholar.id,
@@ -137,7 +137,7 @@ anpm_metric_configuration = MetricConfiguration.create(
 ###############################################################################
 
 dit = NativeMetricSnapshot.create(
-  name: "Depth of Inheritance Tree", description: "", code: "dit", metric_collector_name: "Analizo", scope: "CLASS")
+  name: "Depth of Inheritance Tree", description: "", code: "dit", metric_collector_name: "Analizo", scope: {'type' => "CLASS"})
 
 dit_metric_configuration = MetricConfiguration.create(
   metric_snapshot_id: dit.id, weight: 1.0, aggregation_form: "MEAN", reading_group_id: scholar.id,
@@ -155,7 +155,7 @@ dit_metric_configuration = MetricConfiguration.create(
 ###############################################################################
 
 nom = NativeMetricSnapshot.create(
-  name: "Number of Methods", description: "", code: "nom", metric_collector_name: "Analizo", scope: "CLASS")
+  name: "Number of Methods", description: "", code: "nom", metric_collector_name: "Analizo", scope: {'type' => "CLASS"})
 
 nom_metric_configuration = MetricConfiguration.create(
   metric_snapshot_id: nom.id, weight: 1.0, aggregation_form: "MEAN", reading_group_id: scholar.id,
@@ -173,7 +173,7 @@ nom_metric_configuration = MetricConfiguration.create(
 ###############################################################################
 
 npa = NativeMetricSnapshot.create(
-  name: "Number of Public Attributes", description: "", code: "npa", metric_collector_name: "Analizo", scope: "CLASS")
+  name: "Number of Public Attributes", description: "", code: "npa", metric_collector_name: "Analizo", scope: {'type' => "CLASS"})
 
 npa_metric_configuration = MetricConfiguration.create(
   metric_snapshot_id: npa.id, weight: 1.0, aggregation_form: "MEAN", reading_group_id: scholar.id,
@@ -191,7 +191,7 @@ npa_metric_configuration = MetricConfiguration.create(
 ###############################################################################
 
 sc = NativeMetricSnapshot.create(
-  name: "Structural Complexity", description: "", code: "sc", metric_collector_name: "Analizo", scope: "CLASS")
+  name: "Structural Complexity", description: "", code: "sc", metric_collector_name: "Analizo", scope: {'type' => "CLASS"})
 
 sc_metric_configuration = MetricConfiguration.create(
   metric_snapshot_id: sc.id, weight: 4.0, aggregation_form: "MEAN", reading_group_id: scholar.id,
@@ -213,7 +213,7 @@ sc_metric_configuration = MetricConfiguration.create(
 ruby_configuration = KalibroConfiguration.create(name: "Ruby Configuration", description: "Example Ruby Configuration")
 
 flog = NativeMetricSnapshot.create(
-  name: "Pain", code: "flog", metric_collector_name: "MetricFu", scope: "METHOD",
+  name: "Pain", code: "flog", metric_collector_name: "MetricFu", scope: {'type' => "METHOD"},
   description: "Flog mede a tortuosidade do código-fonte. Quanto mais doloroso e difícil de testar, maior a pontuação, baseando-se na métrica ABC e boas práticas de Ruby. Extraído do blog do autor da métrica: http://jakescruggs.blogspot.com.br/2008/08/whats-good-flog-score.html"
 )
 
@@ -233,7 +233,7 @@ flog_metric_configuration = MetricConfiguration.create(
 ###############################################################################
 
 saikuro = NativeMetricSnapshot.create(
-  name: "Cyclomatic Complexity", code: "saikuro", metric_collector_name: "MetricFu", scope: "METHOD",
+  name: "Cyclomatic Complexity", code: "saikuro", metric_collector_name: "MetricFu", scope: {'type' => "METHOD"},
   description: "Cyclomatic complexity is a graphical measurement of the number of possible paths through the normal flow of a program"
 )
 
@@ -258,7 +258,7 @@ python_configuration = KalibroConfiguration.create(name: "Python",
 ################################################################################
 
 py_cc = NativeMetricSnapshot.create(
-    name: "Cyclomatic Complexity", code: "cc", metric_collector_name: "Radon", scope: "METHOD",
+    name: "Cyclomatic Complexity", code: "cc", metric_collector_name: "Radon", scope: {'type' => "METHOD"},
     description: "Cyclomatic Complexity corresponds to the number of decisions a block of code contains plus 1."
 )
 
@@ -276,7 +276,7 @@ py_cc_metric_configuration = MetricConfiguration.create(
 ################################################################################
 
 py_mi = NativeMetricSnapshot.create(
-    name: "Maintainability Index", code: "mi", metric_collector_name: "Radon", scope: "PACKAGE",
+    name: "Maintainability Index", code: "mi", metric_collector_name: "Radon", scope: {'type' => "PACKAGE"},
     description: "Maintainability Index is a software metric which measures how maintainable (easy to support and change) the source code is. The maintainability index is calculated as a factored formula consisting of SLOC (Source Lines Of Code), Cyclomatic Complexity and Halstead volume."
 )
 
@@ -311,7 +311,7 @@ loc_ranges = [
 ]
 
 py_loc = NativeMetricSnapshot.create(
-    name: "Lines of Code", code: "loc", metric_collector_name: "Radon", scope: "PACKAGE",
+    name: "Lines of Code", code: "loc", metric_collector_name: "Radon", scope: {'type' => "PACKAGE"},
     description: "The total number of lines of code. It is the sum of the SLOC and the number of blank lines: the equation LOC = SLOC + Blanks should always hold."
 )
 py_loc_metric_configuration = MetricConfiguration.create(
@@ -322,7 +322,7 @@ loc_ranges.create_ranges(py_loc_metric_configuration.id)
 ################################################################################
 
 py_lloc = NativeMetricSnapshot.create(
-    name: "Logical Lines of Code", code: "lloc", metric_collector_name: "Radon", scope: "PACKAGE",
+    name: "Logical Lines of Code", code: "lloc", metric_collector_name: "Radon", scope: {'type' => "PACKAGE"},
     description: "The number of logical lines of code. Every logical line of code contains exactly one statement."
 )
 
@@ -334,7 +334,7 @@ loc_ranges.create_ranges(py_lloc_metric_configuration.id)
 ################################################################################
 
 py_sloc = NativeMetricSnapshot.create(
-    name: "Source Lines of Code", code: "sloc", metric_collector_name: "Radon", scope: "PACKAGE",
+    name: "Source Lines of Code", code: "sloc", metric_collector_name: "Radon", scope: {'type' => "PACKAGE"},
     description: "The number of source lines of code - not necessarily corresponding to the LLOC."
 )
 py_sloc_metric_configuration = MetricConfiguration.create(
@@ -355,7 +355,7 @@ indifferent_ranges = [
 ]
 
 py_comments = NativeMetricSnapshot.create(
-    name: "Comment Lines", code: "comments", metric_collector_name: "Radon", scope: "PACKAGE",
+    name: "Comment Lines", code: "comments", metric_collector_name: "Radon", scope: {'type' => "PACKAGE"},
     description: "The number of comment lines. Multi-line strings are not counted as comment since, to the Python interpreter, they are just strings."
 )
 py_comments_metric_configuration = MetricConfiguration.create(
@@ -367,7 +367,7 @@ indifferent_ranges.create_ranges(py_comments_metric_configuration.id)
 ################################################################################
 
 py_multi = NativeMetricSnapshot.create(
-    name: "Multi-line String Lines", code: "multi", metric_collector_name: "Radon", scope: "PACKAGE",
+    name: "Multi-line String Lines", code: "multi", metric_collector_name: "Radon", scope: {'type' => "PACKAGE"},
     description: "The number of lines which represent multi-line strings."
 )
 
@@ -380,7 +380,7 @@ indifferent_ranges.create_ranges(py_multi_metric_configuration.id)
 ################################################################################
 
 py_blank = NativeMetricSnapshot.create(
-    name: "Blank Lines", code: "blank", metric_collector_name: "Radon", scope: "PACKAGE",
+    name: "Blank Lines", code: "blank", metric_collector_name: "Radon", scope: {'type' => "PACKAGE"},
     description: "The number of blank lines (or whitespace-only ones)."
 )
 

--- a/spec/controllers/kalibro_configurations_controller_spec.rb
+++ b/spec/controllers/kalibro_configurations_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe KalibroConfigurationsController, :type => :controller do
   end
 
   describe 'create' do
-    let(:kalibro_configuration_params) { Hash[FactoryGirl.attributes_for(:kalibro_configuration).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with sybols and integers
+    let(:kalibro_configuration_params) { FactoryGirl.attributes_for(:kalibro_configuration).stringify_keys }
 
     context 'with valid attributes' do
       before :each do
@@ -83,7 +83,7 @@ RSpec.describe KalibroConfigurationsController, :type => :controller do
   end
 
   describe 'update' do
-    let(:kalibro_configuration_params) { Hash[FactoryGirl.attributes_for(:kalibro_configuration).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with symbols and integers
+    let(:kalibro_configuration_params) { FactoryGirl.attributes_for(:kalibro_configuration).stringify_keys }
 
     before :each do
       KalibroConfiguration.expects(:find).with(kalibro_configuration.id).returns(kalibro_configuration)

--- a/spec/controllers/kalibro_ranges_controller_spec.rb
+++ b/spec/controllers/kalibro_ranges_controller_spec.rb
@@ -86,10 +86,10 @@ RSpec.describe KalibroRangesController, :type => :controller do
   end
 
   describe 'create' do
-    let!(:range_params) { Hash[FactoryGirl.attributes_for(:kalibro_range,
-                                                          metric_configuration_id: metric_configuration.id, reading_id: reading.id,
-                                                          beginning: "-INF",
-                                                          end: "INF").map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with symbols and integers
+    let!(:range_params) { FactoryGirl.attributes_for(:kalibro_range,
+                                                     metric_configuration_id: metric_configuration.id, reading_id: reading.id,
+                                                     beginning: "-INF",
+                                                     end: "INF").stringify_keys }
 
     context 'successfully saved' do
       before :each do
@@ -117,7 +117,7 @@ RSpec.describe KalibroRangesController, :type => :controller do
     end
 
     context 'failed to save' do
-      let!(:range_params) { Hash[FactoryGirl.attributes_for(:kalibro_range, metric_configuration_id: metric_configuration.id, reading_id: reading.id).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with symbols and integers
+      let!(:range_params) { FactoryGirl.attributes_for(:kalibro_range, metric_configuration_id: metric_configuration.id, reading_id: reading.id).stringify_keys }
       before :each do
         KalibroRange.any_instance.expects(:save).returns(false)
       end
@@ -137,7 +137,7 @@ RSpec.describe KalibroRangesController, :type => :controller do
   end
 
   describe 'update' do
-    let!(:range_params) { Hash[FactoryGirl.attributes_for(:kalibro_range, metric_configuration_id: metric_configuration.id, reading_id: reading.id).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with symbols and integers
+    let!(:range_params) { FactoryGirl.attributes_for(:kalibro_range, metric_configuration_id: metric_configuration.id, reading_id: reading.id).stringify_keys }
 
     before :each do
       KalibroRange.expects(:find).with(range.id).returns(range)

--- a/spec/controllers/metric_configurations_controller_spec.rb
+++ b/spec/controllers/metric_configurations_controller_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe MetricConfigurationsController, :type => :controller do
   let(:metric_configuration) { FactoryGirl.build(:tree_metric_configuration_with_id) }
 
   describe "create" do
-    let!(:metric_configuration_params) { Hash[FactoryGirl.attributes_for(:tree_metric_configuration,
-      kalibro_configuration_id: metric_configuration.kalibro_configuration.id).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with symbols and integers
+    let!(:metric_configuration_params) { FactoryGirl.attributes_for(:tree_metric_configuration,
+                                                                    kalibro_configuration_id: metric_configuration.kalibro_configuration.id).stringify_keys }
 
     # The condition is needed for these workaround is not recursive and MetricSnapshot#scope=
     # requires the scope param to be a Hash, not a String. Otherwise it will add an error
     # to the created instance.
-    let!(:metric_snapshot_params) { Hash[FactoryGirl.attributes_for(:metric_snapshot).map { |k,v| k == :scope ? [k.to_s, v] : [k.to_s, v.to_s] }] }
+    let!(:metric_snapshot_params) { FactoryGirl.attributes_for(:metric_snapshot).stringify_keys }
 
     context "with valid params" do
       before :each do
@@ -71,9 +71,9 @@ RSpec.describe MetricConfigurationsController, :type => :controller do
   end
 
   describe "update" do
-    let(:metric_configuration_params) { Hash[FactoryGirl.attributes_for(:metric_configuration,
-      kalibro_configuration_id: metric_configuration.kalibro_configuration.id,
-      metric_snapshot_id: metric_configuration.metric_snapshot.id).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with symbols and integers
+    let(:metric_configuration_params) { FactoryGirl.attributes_for(:metric_configuration,
+                                                                   kalibro_configuration_id: metric_configuration.kalibro_configuration.id,
+                                                                   metric_snapshot_id: metric_configuration.metric_snapshot.id).stringify_keys }
 
     before :each do
       metric_configuration.metric_snapshot.id = 1
@@ -101,7 +101,7 @@ RSpec.describe MetricConfigurationsController, :type => :controller do
         # The condition is needed for these workaround is not recursive and MetricSnapshot#scope=
         # requires the scope param to be a Hash, not a String. Otherwise it will add an error
         # to the created instance.
-        let!(:metric_snapshot_params) { Hash[FactoryGirl.attributes_for(:compound_metric_snapshot).map { |k,v| k == :scope ? [k.to_s, v] : [k.to_s, v.to_s] }] }
+        let!(:metric_snapshot_params) { FactoryGirl.attributes_for(:compound_metric_snapshot).stringify_keys }
         let(:kalibro_configuration) { FactoryGirl.build(:kalibro_configuration) }
 
         before :each do

--- a/spec/controllers/metric_configurations_controller_spec.rb
+++ b/spec/controllers/metric_configurations_controller_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe MetricConfigurationsController, :type => :controller do
   describe "create" do
     let!(:metric_configuration_params) { Hash[FactoryGirl.attributes_for(:tree_metric_configuration,
       kalibro_configuration_id: metric_configuration.kalibro_configuration.id).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with symbols and integers
-    let!(:metric_snapshot_params) { Hash[FactoryGirl.attributes_for(:metric_snapshot).map { |k,v| [k.to_s, v.to_s] }] }
+
+    # The condition is needed for these workaround is not recursive and MetricSnapshot#scope=
+    # requires the scope param to be a Hash, not a String. Otherwise it will add an error
+    # to the created instance.
+    let!(:metric_snapshot_params) { Hash[FactoryGirl.attributes_for(:metric_snapshot).map { |k,v| k == :scope ? [k.to_s, v] : [k.to_s, v.to_s] }] }
 
     context "with valid params" do
       before :each do
@@ -94,7 +98,10 @@ RSpec.describe MetricConfigurationsController, :type => :controller do
       end
 
       context 'with a CompoundMetricSnapshot' do
-        let!(:metric_snapshot_params) { Hash[FactoryGirl.attributes_for(:compound_metric_snapshot).map { |k,v| [k.to_s, v.to_s] }] }
+        # The condition is needed for these workaround is not recursive and MetricSnapshot#scope=
+        # requires the scope param to be a Hash, not a String. Otherwise it will add an error
+        # to the created instance.
+        let!(:metric_snapshot_params) { Hash[FactoryGirl.attributes_for(:compound_metric_snapshot).map { |k,v| k == :scope ? [k.to_s, v] : [k.to_s, v.to_s] }] }
         let(:kalibro_configuration) { FactoryGirl.build(:kalibro_configuration) }
 
         before :each do

--- a/spec/controllers/reading_groups_controller_spec.rb
+++ b/spec/controllers/reading_groups_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ReadingGroupsController, :type => :controller do
   end
 
   describe 'create' do
-    let(:reading_group_params) { Hash[FactoryGirl.attributes_for(:reading_group).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with sybols and integers
+    let(:reading_group_params) { FactoryGirl.attributes_for(:reading_group).stringify_keys }
 
     context 'with valid attributes' do
       before :each do
@@ -114,7 +114,7 @@ RSpec.describe ReadingGroupsController, :type => :controller do
   end
 
   describe 'update' do
-    let(:reading_group_params) { Hash[FactoryGirl.attributes_for(:reading_group).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with sybols and integers
+    let(:reading_group_params) { FactoryGirl.attributes_for(:reading_group).stringify_keys }
 
     before :each do
       ReadingGroup.expects(:find).with(reading_group.id).returns(reading_group)

--- a/spec/controllers/readings_controller_spec.rb
+++ b/spec/controllers/readings_controller_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe ReadingsController, :type => :controller do
   end
 
   describe "create" do
-    let!(:reading_params) { Hash[FactoryGirl.attributes_for(:reading, reading_group_id: reading.reading_group.id).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with sybols and integers
+    let!(:reading_params) { FactoryGirl.attributes_for(:reading, reading_group_id: reading.reading_group.id).stringify_keys }
 
     context 'with valid attributes' do
       before :each do
@@ -152,7 +152,7 @@ RSpec.describe ReadingsController, :type => :controller do
   end
 
   describe "update" do
-    let!(:reading_params) { Hash[FactoryGirl.attributes_for(:reading, reading_group_id: reading.reading_group.id).map { |k,v| [k.to_s, v.to_s] }] } #FIXME: Mocha is creating the expectations with strings, but FactoryGirl returns everything with sybols and integers
+    let!(:reading_params) { FactoryGirl.attributes_for(:reading, reading_group_id: reading.reading_group.id).stringify_keys }
 
     before :each do
       Reading.expects(:find).with(reading.id).returns(reading)

--- a/spec/factories/compound_metric_snapshots.rb
+++ b/spec/factories/compound_metric_snapshots.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     name "Lines of Code"
     description ""
     code "loc"
-    scope "CLASS"
+    scope { {"type" => "CLASS"} }
     script "return 0;"
   end
 end

--- a/spec/factories/hotspot_metric_snapshots.rb
+++ b/spec/factories/hotspot_metric_snapshots.rb
@@ -5,6 +5,6 @@ FactoryGirl.define do
     description ""
     code "flay"
     metric_collector_name "MetricFu"
-    scope "SOFTWARE"
+    scope { {"type" => "SOFTWARE"} }
   end
 end

--- a/spec/factories/metric_snapshots.rb
+++ b/spec/factories/metric_snapshots.rb
@@ -5,6 +5,6 @@ FactoryGirl.define do
     description ""
     code "loc"
     metric_collector_name "Analizo"
-    scope "CLASS"
+    scope { {"type" => "CLASS"} }
   end
 end

--- a/spec/factories/native_metric_snapshots.rb
+++ b/spec/factories/native_metric_snapshots.rb
@@ -5,6 +5,6 @@ FactoryGirl.define do
     description ""
     code "loc"
     metric_collector_name "Analizo"
-    scope "CLASS"
+    scope { {"type" => "CLASS"} }
   end
 end


### PR DESCRIPTION
Alters the controller and model to handle the new format of the scope attribute of metric snapshots.
For more information on the new scope, see [here](https://github.com/mezuro/kalibro_client/blob/fix_kalibro_module_granularity/lib/kalibro_client/entities/miscellaneous/metric.rb).