### PR TITLE
Add rubocop on default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+task default: [:spec, :cucumber, :rubocop]


### PR DESCRIPTION
That way, rubocop will run automatically after we run all tests.