### PR TITLE
Remove sqlite3 from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'
 
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
-
 # Use PostgreSQL as the database for Active Record
 gem 'pg'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.10)
     sshkit (1.7.1)
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
@@ -271,11 +270,10 @@ DEPENDENCIES
   shoulda-matchers (~> 2.8.0)
   simplecov
   spring
-  sqlite3
   therubyracer
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.2)
 
 BUNDLED WITH
-   1.11.2
+   1.13.1


### PR DESCRIPTION
Since there is no more support for sqlite3, there is no necessity to install it anymore through the Gemfile.