### PR TITLE
Update setup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ KalibroConfigurations is the configuration storage web service for Mezuro.
 
 ## Unreleased
 
+- Do not use bin/rake script on bin/setup anymore
 - Disable rubocop Lint/HandleExceptions cop for rake
 - Drop SQLite 3 support
 

--- a/bin/setup
+++ b/bin/setup
@@ -26,4 +26,9 @@ chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rake log:clear tmp:clear'
 
+  puts "\n== Creating tempfiles  =="
+  system! 'bin/rake tmp:create'
+  puts "touch tmp/restart.txt"
+  system! 'touch tmp/restart.txt'
+
 end

--- a/bin/setup
+++ b/bin/setup
@@ -20,14 +20,14 @@ chdir APP_ROOT do
     cp 'config/database.yml.sample', 'config/database.yml'
   end
 
-  puts "\n== Preparing database =="
-  system! 'bin/rake db:setup'
+  puts "\n== Preparing development database =="
+  system! 'rake db:setup'
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rake log:clear tmp:clear'
+  system! 'rake log:clear tmp:clear'
 
   puts "\n== Creating tempfiles  =="
-  system! 'bin/rake tmp:create'
+  system! 'rake tmp:create'
   puts "touch tmp/restart.txt"
   system! 'touch tmp/restart.txt'
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,29 +1,29 @@
 #!/usr/bin/env ruby
 require 'pathname'
+require 'fileutils'
+include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
+APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
 
-Dir.chdir APP_ROOT do
-  # This script is a starting point to setup your application.
-  # Add necessary setup steps to this file:
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
 
-  puts "== Installing dependencies =="
-  system "gem install bundler --conservative"
-  system "bundle check || bundle install"
+chdir APP_ROOT do
+  puts '== Installing dependencies =='
+  system! 'gem install bundler --conservative'
+  system('bundle check') || system!('bundle install')
 
   puts "\n== Copying sample files =="
-  unless File.exist?("config/database.yml")
-    system "cp config/database.yml.sample config/database.yml"
+  unless File.exist?('config/database.yml')
+    cp 'config/database.yml.sample', 'config/database.yml'
   end
 
   puts "\n== Preparing database =="
-  system "bin/rake db:setup"
+  system! 'bin/rake db:setup'
 
   puts "\n== Removing old logs and tempfiles =="
-  system "rm -f log/*"
-  system "rm -rf tmp/cache"
+  system! 'bin/rake log:clear tmp:clear'
 
-  puts "\n== Restarting application server =="
-  system "touch tmp/restart.txt"
 end


### PR DESCRIPTION
When running bin/setup script, it was not creating the test database. That happened because when bin/rake was loading spring, spring runs by default on the development environment. In order to fix that, we have update the bin/setup script to allow it use rake directly instead of bin/rake.

Also this new version of the setup script fix the problem of creating the necessary files for the tmp dir.

This merge fixes issues #91 and #90 